### PR TITLE
Avoiding pitch changes during teleports

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/CommandTimeTrial.java
+++ b/src/main/java/me/makkuusen/timing/system/CommandTimeTrial.java
@@ -27,6 +27,7 @@ public class CommandTimeTrial extends BaseCommand {
                 player.sendMessage("§cWorld is not loaded!");
                 return;
             }
+            track.getSpawnLocation().setPitch(player.getLocation().getPitch());
             player.teleport(track.getSpawnLocation());
         }
     }

--- a/src/main/java/me/makkuusen/timing/system/TSListener.java
+++ b/src/main/java/me/makkuusen/timing/system/TSListener.java
@@ -506,6 +506,7 @@ public class TSListener implements Listener {
     }
 
     public static void teleportPlayerAndSpawnBoat(Player player, boolean isBoatTrack, Location location){
+        location.setPitch(player.getLocation().getPitch());
         player.teleport(location, PlayerTeleportEvent.TeleportCause.UNKNOWN);
         if (isBoatTrack) {
             Bukkit.getScheduler().runTaskLater(TimingSystem.getPlugin(), () -> {

--- a/src/main/java/me/makkuusen/timing/system/track/GridManager.java
+++ b/src/main/java/me/makkuusen/timing/system/track/GridManager.java
@@ -22,6 +22,7 @@ public class GridManager {
     }
 
     public void teleportPlayerToGrid(Player player, Location location){
+        location.setPitch(player.getLocation().getPitch());
         if (!location.isWorldLoaded()) {
             return;
         }


### PR DESCRIPTION
**Pitch no longer changes with teleporting during:** timetrails, grid loading and checkpoint skipping.

Fixes #83  