### PR TITLE
Added some API calls to get DriverDetails

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/api/DriverDetails.java
+++ b/src/main/java/me/makkuusen/timing/system/api/DriverDetails.java
@@ -1,0 +1,27 @@
+package me.makkuusen.timing.system.api;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class DriverDetails {
+
+    String name;
+    String uuid;
+    String teamColor;
+    boolean offline;
+    boolean inpit = false;
+    int laps;
+    int pits;
+    int position;
+    int startPosition;
+    long gap;
+    long gapFromLeader;
+
+}

--- a/src/main/java/me/makkuusen/timing/system/api/TimingSystemAPI.java
+++ b/src/main/java/me/makkuusen/timing/system/api/TimingSystemAPI.java
@@ -4,6 +4,7 @@ import me.makkuusen.timing.system.ApiUtilities;
 import me.makkuusen.timing.system.Database;
 import me.makkuusen.timing.system.TPlayer;
 import me.makkuusen.timing.system.event.EventDatabase;
+import me.makkuusen.timing.system.heat.Heat;
 import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.timetrial.TimeTrialFinish;
 import me.makkuusen.timing.system.track.Track;
@@ -11,9 +12,11 @@ import me.makkuusen.timing.system.track.TrackDatabase;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class TimingSystemAPI {
 
@@ -60,5 +63,79 @@ public class TimingSystemAPI {
 
     public static void teleportPlayerAndSpawnBoat(Player player, Track track, Location location){
         ApiUtilities.teleportPlayerAndSpawnBoat(player, track, location);
+    }
+
+    public static List<Heat> getHeats(){
+        return EventDatabase.getHeats();
+    }
+
+    public static List<Heat> getRunningHeats() {
+        return EventDatabase.getHeats().stream().filter(Heat::isActive).collect(Collectors.toList());
+    }
+
+    public static List<DriverDetails> getAllDriverDetailsFromHeat(Heat heat) {
+
+        List<DriverDetails> driverDetails = new ArrayList<>();
+        Driver first = null;
+        Driver previous = null;
+        for (Driver d : heat.getLivePositions()) {
+            driverDetails.add(getDriverDetailsFromHeatWithTimes(heat, d.getTPlayer().getUniqueId(), first, previous));
+            if (first == null) {
+                first = d;
+            }
+            previous = d;
+        }
+
+        return driverDetails;
+    }
+
+    private static DriverDetails getDriverDetailsFromHeatWithTimes(Heat heat, UUID driverUuid, Driver previousDriverCompare, Driver leaderDriverCompare) {
+        var driverDetails = getDriverDetailsFromHeat(heat, driverUuid, previousDriverCompare.getTPlayer().getUniqueId());
+        var driver = heat.getDrivers().get(driverUuid);
+
+        if (leaderDriverCompare != null) {
+            driverDetails.setGapFromLeader(driver.getTimeGap(leaderDriverCompare));
+        }
+
+        return driverDetails;
+    }
+
+    public static DriverDetails getDriverDetailsFromHeat(Heat heat, UUID driverUuid, UUID driverCompare) {
+        var driver = heat.getDrivers().get(driverUuid);
+        var driverDetails = new DriverDetails();
+
+        driverDetails.setName(driver.getTPlayer().getName());
+        driverDetails.setUuid(driverUuid.toString());
+        driverDetails.setTeamColor(driver.getTPlayer().getHexColor());
+        driverDetails.setOffline(driver.getTPlayer().getPlayer() == null);
+        if (!driverDetails.isOffline()) {
+            driverDetails.setInpit(driver.isInPit(driver.getTPlayer().getPlayer().getLocation()));
+        }
+        driverDetails.setLaps(driver.getLaps().size());
+        driverDetails.setPits(driver.getPits());
+        driverDetails.setPosition(driver.getPosition());
+        driverDetails.setStartPosition(driver.getStartPosition());
+
+        if (driverCompare != null) {
+            var previousDriverCompare = heat.getDrivers().get(driverCompare);
+            driverDetails.setGap(driver.getTimeGap(previousDriverCompare));
+        }
+
+        return driverDetails;
+    }
+
+    public static DriverDetails getDriverDetailsOfClosestPlayerFromHeat(Heat heat, UUID playerToCheckClosestTo) {
+        Player player = Database.getPlayer(playerToCheckClosestTo).getPlayer();
+        if (player == null) {
+            return new DriverDetails();
+        }
+        var driver = EventDatabase.getClosestDriverForSpectator(player);
+
+        if (driver.isEmpty()) {
+            return new DriverDetails();
+        }
+
+        return getDriverDetailsFromHeat(heat, driver.get().getTPlayer().getUniqueId(), null);
+
     }
 }

--- a/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
@@ -95,11 +95,8 @@ public class DriverScoreboard {
         }
         Location playerLoc = driver.getTPlayer().getPlayer().getLocation();
 
-        var inPitRegions = heat.getEvent().getTrack().getRegions(TrackRegion.RegionType.INPIT);
-        for (TrackRegion trackRegion : inPitRegions) {
-            if (trackRegion.contains(playerLoc)){
-                return ScoreboardUtils.getDriverLineRaceInPit(driver.getTPlayer().getName(), driver.getPits(), driver.getPosition());
-            }
+        if (driver.isInPit(playerLoc)) {
+            return ScoreboardUtils.getDriverLineRaceInPit(driver.getTPlayer().getName(), driver.getPits(), driver.getPosition());
         }
 
         if (driver.getPosition() < comparingDriver.getPosition()) {


### PR DESCRIPTION
So I did what I understood from the issue with minimal tweaks.

If you want the gap to another driver, you need to specify which driver in the TimingSystemAPI.getDriverDetailsFromHeat()

I'm also unsure of the getDriverDetailsOfClosestPlayerFromHeat(Heat heat, UUID playerToCheckClosestTo) is supposed to give the physical closest driver from the "playerToCheckClosestTo", or if it is meant to be the closest as the closest driver, either ahead or behind? Right now it is the first option, but it could of course change.

(I'm also not 100% the gap value is going to be working perfect, but I think it will. I guess some testing is needed.)

@JustBru00 Feel free to check this out.
