### PR TITLE
Basic Oink Scoreboard Support

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
@@ -55,15 +55,9 @@ public class SpectatorScoreboard {
 
     public List<String> normalScoreboard(){
         List<String> lines = new ArrayList<>();
-        int count = 0;
-        int last = 15;
         Driver prevDriver = null;
         boolean compareToFirst = true;
         for (Driver driver : heat.getLivePositions()) {
-            count++;
-            if (count > last) {
-                break;
-            }
             if (heat.getRound() instanceof QualificationRound) {
                 lines.add(getDriverRowQualy(driver, prevDriver));
                 if (compareToFirst) {


### PR DESCRIPTION
Removes the limit of scoreboard rows sent to spectators. I don't believe this harms players without the mod but should possibly be tested.
Drivers (with or without the mod) should not be affected by this change.