### PR TITLE
Adds a cooldown to the /boat command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This plugin has made it's first real release. If you want to use it, make sure t
 4. [optional] [HolographicDisplays 3.0.0](https://dev.bukkit.org/projects/holographic-displays/files/4056176/download)
 
 ## Add-ons
-* [Unofficial] [TimingSystemRESTApi](https://github.com/JustBru00/TimingSystemRESTApi) - Adds a basic JSON REST API to the TimingSystem plugin.
+* [Unofficial] [TimingSystemRESTApi](https://github.com/JustBru00/TimingSystemRESTApi) - Adds a basic JSON REST API to the TimingSystem plugin.     
+* [Unofficial] [TimingSystemBlueMap](https://github.com/JustBru00/TimingSystemBlueMap) - Adds TimingSystem track locations to [BlueMap](https://github.com/BlueMap-Minecraft/BlueMap).     
 
 ## Discord
 If you need support. Look for #support in our discord.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.makkuusen.timing.system</groupId>
     <artifactId>TimingSystem</artifactId>
-    <version>1.4-rc.1</version>
+    <version>1.4-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/makkuusen/timing/system/CommandBoat.java
+++ b/src/main/java/me/makkuusen/timing/system/CommandBoat.java
@@ -15,7 +15,11 @@ public class CommandBoat extends BaseCommand {
         if (isPlayerInBoat(player)) {
             return;
         }
-        ApiUtilities.spawnBoatAndAddPlayer(player, player.getLocation());
+        
+        if (CommandCooldownManager.isCommandBoatCooldownComplete(player)) {
+        	 ApiUtilities.spawnBoatAndAddPlayer(player, player.getLocation());
+        	 return;
+        }         	
     }
 
     private static boolean isPlayerInBoat(Player p) {

--- a/src/main/java/me/makkuusen/timing/system/CommandCooldownManager.java
+++ b/src/main/java/me/makkuusen/timing/system/CommandCooldownManager.java
@@ -1,0 +1,64 @@
+package me.makkuusen.timing.system;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+
+
+public class CommandCooldownManager {
+
+	private static HashMap<UUID, Instant> commandBoatLastUsed = new HashMap<UUID, Instant>();
+	private static final long COMMAND_BOAT_DEFAULT_COOLDOWN = 3000;
+
+	/**
+	 * This method checks if the cooldown is complete for the /boat command.
+	 * This method will send a cooldown message to the player if required.
+	 *
+	 * @param player The {@link Player} who is performing the command.
+	 * @return This method will return true if the cooldown is complete or it will
+	 *         return false if the cooldown is not finished.
+	 */
+	public static boolean isCommandBoatCooldownComplete(Player player) {
+		if (TimingSystem.getPlugin().getConfig().getLong("commandcooldowns.boat") < 0) {
+			// Disable /boat cooldown if cooldown is set below 0
+			return true;
+		}
+		
+		UUID uuid = player.getUniqueId();
+		if (commandBoatLastUsed.containsKey(uuid)) {
+			// Has used /boat command since last reboot.
+			Instant lastUsed = commandBoatLastUsed.get(uuid);
+			long millsUntilNextUse = Duration.between(lastUsed, Instant.now()).toMillis();
+
+			if (millsUntilNextUse > getCommandBoatCooldownFromConfig()) {
+				// Allow command again
+				commandBoatLastUsed.put(uuid, Instant.now());
+				return true;
+			} else {
+				// Send wait for cooldown message
+				String message = TimingSystem.getPlugin().getLocalizedMessage(player, "messages.error.commandCooldownGeneric", 
+	        			"%cooldownRemaining%", ApiUtilities.formatAsTime(getCommandBoatCooldownFromConfig()-millsUntilNextUse));      
+				player.sendMessage(message);
+				return false;
+			}
+
+		}
+
+		// Hasn't used /boat since the last reboot.
+		commandBoatLastUsed.put(uuid, Instant.now());
+		return true;
+
+	}
+
+	private static long getCommandBoatCooldownFromConfig() {
+		long boatCommandCooldown = TimingSystem.getPlugin().getConfig().getLong("commandcooldowns.boat");
+
+		if (boatCommandCooldown == 0) {
+			boatCommandCooldown = COMMAND_BOAT_DEFAULT_COOLDOWN;
+		} 
+		return boatCommandCooldown;
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,3 +28,5 @@ sql:
    database: ''
    username: ''
    password: ''
+commandcooldowns:
+  boat: 3000   

--- a/src/main/resources/en_us.yml
+++ b/src/main/resources/en_us.yml
@@ -32,6 +32,7 @@ messages:
     timer:
       missedCheckpoints: '&cTime is invalid, not all checkpoints were passed!'
       leftBoat: '&cYou left the boat and cancelled your time.'
+    commandCooldownGeneric: '&cThat command is on cooldown. Please wait %cooldownRemaining% before using this command again.'  
   save:
     generic: '&aValue has been saved.'
   create:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: TimingSystem
 main: me.makkuusen.timing.system.TimingSystem
-version: 1.3
-authors: [Markus Hellquist (Makkuusen)]
+version: 1.4
+authors: [Markus Hellquist (Makkuusen), GitHub Repository Contributors]
 depend: [WorldEdit]
 softdepend: [HolographicDisplays, Multiverse-Core]
 api-version: 1.19


### PR DESCRIPTION
The cooldown defaults to 3000.
Use `commandcooldowns.boat` in config.yml to set the cooldown.

Added cooldown message: `messages.error.commandCooldownGeneric`

To disable the cooldown, set `commandcooldowns.boat` to a negative number such as -1.