### PR TITLE
Replace deprecated scoreboard library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,10 +176,21 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.JordanOsterberg.JScoreboards</groupId>
-            <artifactId>JScoreboards</artifactId>
-            <version>b640d7b595</version>
-            <scope>compile</scope>
+            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <artifactId>scoreboard-library-api</artifactId>
+            <version>2.0.0-RC12</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <artifactId>scoreboard-library-implementation</artifactId>
+            <version>2.0.0-RC12</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <artifactId>scoreboard-library-modern</artifactId>
+            <version>2.0.0-RC12</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,18 +178,18 @@
         <dependency>
             <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
             <artifactId>scoreboard-library-api</artifactId>
-            <version>2.0.0-RC12</version>
+            <version>daa32239b9</version>
         </dependency>
         <dependency>
             <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
             <artifactId>scoreboard-library-implementation</artifactId>
-            <version>2.0.0-RC12</version>
+            <version>daa32239b9</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
             <artifactId>scoreboard-library-modern</artifactId>
-            <version>2.0.0-RC12</version>
+            <version>daa32239b9</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/makkuusen/timing/system/TPlayer.java
+++ b/src/main/java/me/makkuusen/timing/system/TPlayer.java
@@ -7,14 +7,15 @@ import co.aikar.commands.MessageKeys;
 import co.aikar.commands.contexts.ContextResolver;
 import co.aikar.idb.DB;
 import co.aikar.idb.DbRow;
-import dev.jcsoftware.jscoreboards.JPerPlayerMethodBasedScoreboard;
 import me.makkuusen.timing.system.event.EventDatabase;
 import me.makkuusen.timing.system.gui.BaseGui;
 import me.makkuusen.timing.system.gui.TrackFilter;
 import me.makkuusen.timing.system.gui.TrackSort;
 import me.makkuusen.timing.system.theme.Theme;
 import me.makkuusen.timing.system.track.Track;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
+import net.megavex.scoreboardlibrary.api.sidebar.Sidebar;
 import org.bukkit.Material;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Player;
@@ -26,7 +27,7 @@ import java.util.UUID;
 public class TPlayer implements Comparable<TPlayer> {
     private final TimingSystem plugin;
     private final UUID uuid;
-    JPerPlayerMethodBasedScoreboard jScoreboard;
+    private Sidebar scoreboard;
     private Player player;
     private String name;
     private Boat.Type boat;
@@ -81,40 +82,42 @@ public class TPlayer implements Comparable<TPlayer> {
         if (player == null) {
             return;
         }
-        if (jScoreboard == null) {
-            jScoreboard = new JPerPlayerMethodBasedScoreboard();
-            jScoreboard.addPlayer(player);
+        if (scoreboard == null) {
+            scoreboard = TimingSystem.scoreboardLibrary.createSidebar();
+            scoreboard.addPlayer(player);
         }
     }
 
     public void clearScoreboard() {
-        if (jScoreboard != null) {
-            jScoreboard.destroy();
-            jScoreboard = null;
+        if (scoreboard != null) {
+            scoreboard.close();
+            scoreboard = null;
         }
     }
 
-    public void setScoreBoardTitle(String title) {
+    public void setScoreBoardTitle(Component title) {
         if (player == null) {
             return;
         }
-        if (jScoreboard == null) {
+        if (scoreboard == null) {
             initScoreboard();
         }
 
-        jScoreboard.setTitle(player, title);
+        scoreboard.title(title);
     }
 
-    public void setScoreBoardLines(List<String> lines) {
+    public void setScoreBoardLines(List<Component> lines) {
         if (player == null) {
             return;
         }
 
-        if (jScoreboard == null) {
+        if (scoreboard == null) {
             initScoreboard();
         }
 
-        jScoreboard.setLines(player, lines);
+        for(Component line : lines) {
+            scoreboard.line(lines.indexOf(line), line);
+        }
     }
 
     public BaseGui getOpenGui() {

--- a/src/main/java/me/makkuusen/timing/system/TPlayer.java
+++ b/src/main/java/me/makkuusen/timing/system/TPlayer.java
@@ -83,7 +83,7 @@ public class TPlayer implements Comparable<TPlayer> {
             return;
         }
         if (scoreboard == null) {
-            scoreboard = TimingSystem.scoreboardLibrary.createSidebar();
+            scoreboard = TimingSystem.scoreboardLibrary.createSidebar(TimingSystem.configuration.getScoreboardMaxRows());
             scoreboard.addPlayer(player);
         }
     }

--- a/src/main/java/me/makkuusen/timing/system/TimingSystem.java
+++ b/src/main/java/me/makkuusen/timing/system/TimingSystem.java
@@ -35,6 +35,9 @@ import me.makkuusen.timing.system.track.TrackRegion;
 import me.makkuusen.timing.system.track.TrackTag;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.megavex.scoreboardlibrary.api.ScoreboardLibrary;
+import net.megavex.scoreboardlibrary.api.exception.NoPacketAdapterAvailableException;
+import net.megavex.scoreboardlibrary.api.noop.NoopScoreboardLibrary;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Boat;
@@ -60,6 +63,7 @@ public class TimingSystem extends JavaPlugin {
     public static Map<UUID, TPlayer> players = new HashMap<>();
     private static LanguageManager languageManager;
     public static Instant currentTime = Instant.now();
+    public static ScoreboardLibrary scoreboardLibrary;
 
     public static Theme defaultTheme = new Theme();
     private static TaskChainFactory taskChainFactory;
@@ -73,6 +77,12 @@ public class TimingSystem extends JavaPlugin {
         Database.plugin = this;
         Text.plugin = this;
         languageManager = new LanguageManager(this, "en_us");
+
+        try {
+            scoreboardLibrary = ScoreboardLibrary.loadScoreboardLibrary(plugin);
+        } catch(NoPacketAdapterAvailableException e) {
+            scoreboardLibrary = new NoopScoreboardLibrary();
+        }
 
         PluginManager pm = Bukkit.getPluginManager();
         pm.registerEvents(new GUIListener(), plugin);
@@ -267,6 +277,7 @@ public class TimingSystem extends JavaPlugin {
     public void onDisable() {
         EventDatabase.getHeats().stream().filter(Heat::isActive).forEach(Heat::onShutdown);
         logger.info("Version " + getPluginMeta().getVersion() + " disabled.");
+        scoreboardLibrary.close();
         DB.close();
         Database.plugin = null;
         TSListener.plugin = null;

--- a/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
@@ -5,6 +5,8 @@ import me.makkuusen.timing.system.TimingSystem;
 import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.round.QualificationRound;
 import me.makkuusen.timing.system.theme.Theme;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 
 import java.time.Duration;
@@ -32,7 +34,7 @@ public class DriverScoreboard {
             eventName = heat.getEvent().getDisplayName();
         }
 
-        tPlayer.setScoreBoardTitle(ScoreboardUtils.getPrimaryColor(tPlayer.getTheme()) + "&l" + heat.getName() + " | " + eventName);
+        tPlayer.setScoreBoardTitle(Component.text(heat.getName() + " | " + eventName).color(ScoreboardUtils.getPrimaryColor(tPlayer.getTheme())).decorate(TextDecoration.BOLD));
     }
 
     public void removeScoreboard() {
@@ -45,7 +47,7 @@ public class DriverScoreboard {
     }
 
     public void setLines() {
-        List<String> lines;
+        List<Component> lines;
         int pos = driver.getPosition();
         if (pos > 12 && heat.getLivePositions().size() > 15) {
             lines = individualScoreboard();
@@ -55,8 +57,8 @@ public class DriverScoreboard {
         tPlayer.setScoreBoardLines(lines);
     }
 
-    public List<String> individualScoreboard() {
-        List<String> lines = new ArrayList<>();
+    public List<Component> individualScoreboard() {
+        List<Component> lines = new ArrayList<>();
         int count = 0;
         int last = Math.min(driver.getPosition() + 7, heat.getDrivers().size());
         int first = last - 14;
@@ -78,8 +80,8 @@ public class DriverScoreboard {
         return lines;
     }
 
-    public List<String> normalScoreboard() {
-        List<String> lines = new ArrayList<>();
+    public List<Component> normalScoreboard() {
+        List<Component> lines = new ArrayList<>();
         int count = 0;
         int last = TimingSystem.configuration.getScoreboardMaxRows();
         for (Driver driver : heat.getLivePositions()) {
@@ -97,7 +99,7 @@ public class DriverScoreboard {
         return lines;
     }
 
-    private String getDriverRowFinal(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
+    private Component getDriverRowFinal(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
         if (driver.getLaps().size() < 1) {
             return ScoreboardUtils.getDriverLineRace(driver, driver.getPosition(), compact, theme);
         }
@@ -149,7 +151,7 @@ public class DriverScoreboard {
         return ScoreboardUtils.getDriverLineRace(driver, driver.getPits(), driver.getPosition(), compact, theme);
     }
 
-    private String getDriverRowQualification(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
+    private Component getDriverRowQualification(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
         if (driver.getBestLap().isEmpty()) {
             return ScoreboardUtils.getDriverLine(driver, driver.getPosition(), compact, theme);
         }

--- a/src/main/java/me/makkuusen/timing/system/heat/ScoreboardUtils.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/ScoreboardUtils.java
@@ -3,157 +3,152 @@ package me.makkuusen.timing.system.heat;
 import me.makkuusen.timing.system.ApiUtilities;
 import me.makkuusen.timing.system.participant.Driver;
 import me.makkuusen.timing.system.theme.Theme;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public class ScoreboardUtils {
-    public static String getDriverLine(Driver driver, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + "           " + getTeamIcon(driver) + paddName(driver, compact);
+    public static Component getDriverLine(Driver driver, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text("           ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).build();
     }
 
-    public static String getDriverLineQualyTime(long laptime, Driver driver, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " " + getSecondaryColor(theme) + paddTime(ApiUtilities.formatAsTime(laptime)) + getTeamIcon(driver) + paddName(driver, compact);
+    public static Component getDriverLineQualyTime(long laptime, Driver driver, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" ")).append(paddTime(ApiUtilities.formatAsTime(laptime)).color(getSecondaryColor(theme))).append(getTeamIcon(driver)).append(paddName(driver, compact)).build();
     }
 
-    public static String getDriverLineQualyGap(long timeDiff, Driver driver, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " §a+" + paddGap(ApiUtilities.formatAsQualificationGap(timeDiff)) + getTeamIcon(driver) + paddName(driver, compact);
+    public static Component getDriverLineQualyGap(long timeDiff, Driver driver, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" +").color(NamedTextColor.GREEN)).append(paddGap(ApiUtilities.formatAsQualificationGap(timeDiff))).append(getTeamIcon(driver)).append(paddName(driver, compact)).build();
     }
 
-    public static String getDriverLineNegativeQualyGap(long timeDiff, Driver driver, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " §c-" + paddGap(ApiUtilities.formatAsQualificationGap(timeDiff)) + getTeamIcon(driver) + paddName(driver, compact);
+    public static Component getDriverLineNegativeQualyGap(long timeDiff, Driver driver, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" -").color(NamedTextColor.RED)).append(paddGap(ApiUtilities.formatAsQualificationGap(timeDiff))).append(getTeamIcon(driver)).append(paddName(driver, compact)).build();
     }
 
-    public static String getDriverLineRace(Driver driver, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + "           " + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + "§f0";
+    public static Component getDriverLineRace(Driver driver, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text("           ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(0).color(TextColor.color(0xFFFFFF))).build();
     }
 
-    public static String getDriverLineRace(Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + "           " + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineRace(Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text("           ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    public static String getDriverLineRaceInPit(Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " In Pit   " + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineRaceInPit(Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" In Pit   ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    public static String getDriverLineRaceOffline(Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " Offline  " + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineRaceOffline(Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" Offline  ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    public static String getDriverLineRaceLaps(int laps, Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " Lap: " + getSecondaryColor(theme) + paddLaps(laps) + " " + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineRaceLaps(int laps, Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" Lap: ")).append(paddLaps(laps).color(getSecondaryColor(theme))).append(Component.text(" ")).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    public static String getDriverLineRaceGap(long gap, Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " §a+" + paddGap(ApiUtilities.formatAsRacingGap(gap)) + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineRaceGap(long gap, Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" +").color(NamedTextColor.GREEN)).append(paddGap(ApiUtilities.formatAsRacingGap(gap))).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    public static String getDriverLineNegativeRaceGap(long gap, Driver driver, int pits, int pos, boolean compact, Theme theme) {
-        return paddPos(pos, driver) + (compact ? "" : getDivider(theme)) + " §c-" + paddGap(ApiUtilities.formatAsRacingGap(gap)) + getTeamIcon(driver) + paddName(driver, compact) + getPits(compact, theme) + getPitColour(driver, pits);
+    public static Component getDriverLineNegativeRaceGap(long gap, Driver driver, int pits, int pos, boolean compact, Theme theme) {
+        return Component.text().append(paddPos(pos, driver)).append((compact ? Component.empty() : getDivider(theme))).append(Component.text(" -").color(NamedTextColor.RED)).append(paddGap(ApiUtilities.formatAsRacingGap(gap))).append(getTeamIcon(driver)).append(paddName(driver, compact)).append(getPits(compact, theme)).append(Component.text(pits).color(getPitColour(driver, pits))).build();
     }
 
-    private static String getDivider(Theme theme) {
-        return getPrimaryColor(theme) + "|";
+    private static Component getDivider(Theme theme) {
+        return Component.text("|").color(getPrimaryColor(theme));
     }
 
-    public static String paddName(Driver driver, boolean compact) {
+    public static Component paddName(Driver driver, boolean compact) {
         return paddName(driver.getTPlayer().getName(), compact);
     }
-    public static String paddName(String name, boolean compact) {
 
-        StringBuilder sb = new StringBuilder();
+    public static Component paddName(String name, boolean compact) {
+
+        TextComponent.Builder c = Component.text().content("");
         if (compact) {
             if (name.length() > 3) {
-                sb.append(name, 0, 4);
+                c.append(Component.text(name.substring(0, 4)));
             } else {
-                sb.append(name);
+                c.append(Component.text(name));
                 int spaces = 4 - name.length();
-                sb.append(" ".repeat(Math.max(0, spaces)));
+                c.append(Component.text(" ".repeat(Math.max(0, spaces))));
             }
         } else {
-            sb.append(name + ChatColor.RESET);
+            c.append(Component.text(name));
             int spaces = 16 - name.length();
-            sb.append(" ".repeat(Math.max(0, spaces)));
+            c.append(Component.text(" ".repeat(Math.max(0, spaces))));
         }
-        return sb.toString();
+        return c.build();
     }
 
-    public static String paddPos(int pos, Driver driver) {
-        if (pos > 9) {
-            return getPosFormat(pos, driver) + pos;
-        }
-        return getPosFormat(pos, driver) + pos + "§r ";
-    }
+    public static Component paddPos(int pos, Driver driver) {
+        TextColor posColour;
 
-    public static String paddGap(String gap) {
-        if (gap.length() == 5) {
-            return gap + "  ";
-        }
-        return gap;
-    }
-
-    public static String paddTime(String time) {
-        if (time.length() == 6) {
-            return time + "  ";
-        }
-        return time;
-    }
-
-    public static String paddLaps(int laps) {
-        if (laps < 10) {
-            return "0" + laps;
-        }
-        return String.valueOf(laps);
-    }
-
-    private static String getPitColour(Driver driver, int pits) {
-        if (driver.getPits() >= driver.getHeat().getTotalPits()) return "§a" + pits;
-        else if (driver.getPits() > 0) return "§6" + pits;
-        else return "§c" + pits;
-    }
-
-    public static String getSecondaryColor(Theme theme) {
-        return String.valueOf(net.md_5.bungee.api.ChatColor.of(theme.getSecondary().asHexString()));
-    }
-
-    public static String getPrimaryColor(Theme theme) {
-        return String.valueOf(net.md_5.bungee.api.ChatColor.of(theme.getPrimary().asHexString()));
-    }
-
-    private static String getPosFormat(int pos, Driver driver) {
-
-        net.md_5.bungee.api.ChatColor posColour;
-
-        switch (pos) {
-            case 1 -> posColour = net.md_5.bungee.api.ChatColor.of("#f6f31a");
-            case 2 -> posColour = net.md_5.bungee.api.ChatColor.of("#c3c3c3");
-            case 3 -> posColour = net.md_5.bungee.api.ChatColor.of("#CD7F32");
-            default -> posColour = net.md_5.bungee.api.ChatColor.of("#ffffff");
+        switch(pos) {
+            case 1 -> posColour = TextColor.color(0xF6F31A);
+            case 2 -> posColour = TextColor.color(0xC3C3C3);
+            case 3 -> posColour = TextColor.color(0xCD7F32);
+            default -> posColour = TextColor.color(0xFFFFFF);
         }
 
+        TextComponent.Builder b = Component.text().content(String.valueOf(pos)).color(posColour);
         boolean hasFastestLap = driver.getHeat().getFastestLapUUID() == driver.getTPlayer().getUniqueId();
 
-        if (driver.isFinished() && hasFastestLap) {
-            return posColour + String.valueOf(ChatColor.UNDERLINE) + ChatColor.ITALIC;
+        if(hasFastestLap) b.decorate(TextDecoration.UNDERLINED);
+        if(driver.isFinished()) b.decorate(TextDecoration.ITALIC);
 
-        } else if (driver.isFinished()) {
-            return posColour + String.valueOf(ChatColor.ITALIC);
-
-        } else if (hasFastestLap) {
-            return posColour + String.valueOf(ChatColor.UNDERLINE);
-
-        } else {
-            return String.valueOf(posColour);
+        if(!(pos > 9)) {
+            b.append(Component.text(" ").decoration(TextDecoration.UNDERLINED, false).decoration(TextDecoration.ITALIC, false));
         }
+
+        return b.build();
     }
 
-    private static String getTeamIcon(Driver driver) {
-        return driver.getTPlayer().getColorCode() + "§l§o||§r ";
+    public static Component paddGap(String gap) {
+        if (gap.length() == 5) {
+            return Component.text(gap + "  ");
+        }
+        return Component.text(gap);
     }
 
-    private static String getPits(boolean compact, Theme theme) {
+    public static Component paddTime(String time) {
+        if (time.length() == 6) {
+            return Component.text(time + "  ");
+        }
+        return Component.text(time);
+    }
+
+    public static Component paddLaps(int laps) {
+        if (laps < 10) {
+            return Component.text("0" + laps);
+        }
+        return Component.text(laps);
+    }
+
+    private static TextColor getPitColour(Driver driver, int pits) {
+        TextColor color = NamedTextColor.RED;
+        if (pits >= driver.getHeat().getTotalPits()) color = NamedTextColor.GREEN;
+        else if (pits > 0) color = NamedTextColor.GOLD;
+        return color;
+    }
+
+    public static TextColor getSecondaryColor(Theme theme) {
+        return theme.getSecondary();
+    }
+
+    public static TextColor getPrimaryColor(Theme theme) {
+        return TextColor.color(theme.getPrimary().value());
+    }
+
+    private static Component getTeamIcon(Driver driver) {
+        return Component.text("§l§o||§r ").color(driver.getTPlayer().getTextColor());
+    }
+
+    private static Component getPits(boolean compact, Theme theme) {
         if (compact) {
-            return " ";
+            return Component.text(" ");
         }
-        return getPrimaryColor(theme) + "Pits: ";
+        return Component.text("Pits: ").color(getPrimaryColor(theme));
     }
 
 }

--- a/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
@@ -7,6 +7,8 @@ import me.makkuusen.timing.system.participant.Spectator;
 import me.makkuusen.timing.system.round.QualificationRound;
 import me.makkuusen.timing.system.theme.Theme;
 import me.makkuusen.timing.system.track.TrackRegion;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 
 import java.time.Duration;
@@ -27,7 +29,7 @@ public class SpectatorScoreboard {
             if (!heat.getDrivers().containsKey(spec.getTPlayer().getUniqueId())) {
                 if (spec.getTPlayer().getPlayer() != null) {
                     spec.getTPlayer().initScoreboard();
-                    List<String> lines;
+                    List<Component> lines;
                     lines = normalScoreboard(spec.getTPlayer());
                     setTitle(spec.getTPlayer());
                     spec.getTPlayer().setScoreBoardLines(lines);
@@ -44,7 +46,7 @@ public class SpectatorScoreboard {
             eventName = heat.getEvent().getDisplayName();
         }
 
-        tPlayer.setScoreBoardTitle(ScoreboardUtils.getPrimaryColor(tPlayer.getTheme()) + "&l" + heat.getName() + " | " + eventName);
+        tPlayer.setScoreBoardTitle(Component.text(heat.getName() + " | " + eventName).color(ScoreboardUtils.getPrimaryColor(tPlayer.getTheme())).decorate(TextDecoration.BOLD));
     }
 
     public void removeScoreboards() {
@@ -53,8 +55,8 @@ public class SpectatorScoreboard {
         }
     }
 
-    public List<String> normalScoreboard(TPlayer tPlayer) {
-        List<String> lines = new ArrayList<>();
+    public List<Component> normalScoreboard(TPlayer tPlayer) {
+        List<Component> lines = new ArrayList<>();
         int count = 0;
         int last = TimingSystem.configuration.getScoreboardMaxRows();
         Driver prevDriver = null;
@@ -79,7 +81,7 @@ public class SpectatorScoreboard {
         return lines;
     }
 
-    private String getDriverRowFinal(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
+    private Component getDriverRowFinal(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
         if (driver.getLaps().size() < 1) {
             return ScoreboardUtils.getDriverLineRace(driver, driver.getPosition(), compact, theme);
         }
@@ -114,7 +116,7 @@ public class SpectatorScoreboard {
         return ScoreboardUtils.getDriverLineRaceGap(timeDiff, driver, driver.getPits(), driver.getPosition(), compact, theme);
     }
 
-    private String getDriverRowQualification(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
+    private Component getDriverRowQualification(Driver driver, Driver comparingDriver, boolean compact, Theme theme) {
         if (driver.getBestLap().isEmpty()) {
             return ScoreboardUtils.getDriverLine(driver, driver.getPosition(), compact, theme);
         }

--- a/src/main/java/me/makkuusen/timing/system/timetrial/TimeTrialScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/timetrial/TimeTrialScoreboard.java
@@ -4,7 +4,9 @@ import me.makkuusen.timing.system.ApiUtilities;
 import me.makkuusen.timing.system.TPlayer;
 import me.makkuusen.timing.system.theme.Text;
 import me.makkuusen.timing.system.theme.messages.ScoreBoard;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 import java.util.ArrayList;
@@ -18,7 +20,7 @@ public class TimeTrialScoreboard {
         this.tPlayer = tPlayer;
         tPlayer.initScoreboard();
         this.timeTrialSession = timeTrialsession;
-        tPlayer.setScoreBoardTitle(getColor(tPlayer.getTheme().getPrimary()) + "&l" + timeTrialsession.track.getDisplayName());
+        tPlayer.setScoreBoardTitle(Component.text(timeTrialsession.track.getDisplayName()).color(tPlayer.getTheme().getPrimary()).decorate(TextDecoration.BOLD));
     }
 
     public void removeScoreboard() {
@@ -30,7 +32,7 @@ public class TimeTrialScoreboard {
     }
 
     public void setLines() {
-        List<String> lines = new ArrayList<>();
+        List<Component> lines = new ArrayList<>();
 
         long totalTime = 0;
         long totalFinishes = timeTrialSession.getTimeTrialFinishes().size();
@@ -67,17 +69,17 @@ public class TimeTrialScoreboard {
             averageTime = totalTime / totalFinishes;
         }
 
-        String color = getColor(tPlayer.getTheme().getError());
+        TextColor color = tPlayer.getTheme().getError();
         if (percentage > 67) {
-            color = getColor(tPlayer.getTheme().getSuccess());
+            color = tPlayer.getTheme().getSuccess();
         } else if (percentage > 33) {
-            color = getColor(tPlayer.getTheme().getWarning());
+            color = tPlayer.getTheme().getWarning();
         }
 
-        lines.add(getColor(tPlayer.getTheme().getSecondary()) + PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.FINISHES)) + color + (totalAttempts != 0 ? totalFinishes + "/" + totalAttempts + " (" + percentage + "%)" : "(-)"));
-        lines.add(getColor(tPlayer.getTheme().getSecondary()) + PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.AVERAGE_TIME)) + getColor(tPlayer.getTheme().getWarning()) + (averageTime != -1 ? ApiUtilities.formatAsTimeNoRounding(averageTime) : "(-)"));
-        lines.add(getColor(tPlayer.getTheme().getSecondary()) + PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.BEST_TIME)) + getColor(tPlayer.getTheme().getSuccess()) + (bestTime != -1 ? ApiUtilities.formatAsTime(bestTime) : "(-)"));
-        lines.add("");
+        lines.add(Component.text(PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.FINISHES))).color(tPlayer.getTheme().getSecondary()).append(Component.text((totalAttempts != 0 ? totalFinishes + "/" + totalAttempts + " (" + percentage + "%)" : "(-)"))).color(color));
+        lines.add(Component.text(PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.AVERAGE_TIME))).color(tPlayer.getTheme().getSecondary()).append(Component.text((averageTime != -1 ? ApiUtilities.formatAsTimeNoRounding(averageTime) : "(-)"))).color(tPlayer.getTheme().getWarning()));
+        lines.add(Component.text(PlainTextComponentSerializer.plainText().serialize(Text.get(tPlayer, ScoreBoard.BEST_TIME))).color(tPlayer.getTheme().getSecondary()).append(Component.text((bestTime != -1 ? ApiUtilities.formatAsTime(bestTime) : "(-)"))).color(tPlayer.getTheme().getSuccess()));
+        lines.add(Component.empty());
         int count = timeTrialSession.getTimeTrialFinishes().size();
 
         int limit = Math.max(0, count - 10);
@@ -85,18 +87,14 @@ public class TimeTrialScoreboard {
             for (int i = count; i > limit; i--) {
                 long time = timeTrialSession.getTimeTrialFinishes().get(i - 1).getTime();
                 if (time == bestTime) {
-                    lines.add(getColor(tPlayer.getTheme().getPrimary()) + i + ". " + getColor(tPlayer.getTheme().getSuccess()) + ApiUtilities.formatAsTime(time));
+                    lines.add(Component.text(i + ". ").color(tPlayer.getTheme().getPrimary()).append(Component.text(ApiUtilities.formatAsTime(time)).color(tPlayer.getTheme().getSuccess())));
                 } else if (time == slowestTime) {
-                    lines.add(getColor(tPlayer.getTheme().getPrimary()) + i + ". " + getColor(tPlayer.getTheme().getError()) + ApiUtilities.formatAsTime(time));
+                    lines.add(Component.text(i + ". ").color(tPlayer.getTheme().getPrimary()).append(Component.text(ApiUtilities.formatAsTime(time)).color(tPlayer.getTheme().getError())));
                 } else {
-                    lines.add(getColor(tPlayer.getTheme().getPrimary()) + i + ". " + getColor(tPlayer.getTheme().getSecondary()) + ApiUtilities.formatAsTime(time));
+                    lines.add(Component.text(i + ". ").color(tPlayer.getTheme().getPrimary()).append(Component.text(ApiUtilities.formatAsTime(time)).color(tPlayer.getTheme().getSecondary())));
                 }
             }
         }
         tPlayer.setScoreBoardLines(lines);
-    }
-
-    private static String getColor(TextColor color) {
-        return String.valueOf(net.md_5.bungee.api.ChatColor.of(color.asHexString()));
     }
 }


### PR DESCRIPTION
Replaces the deprecated library [JScoreboard](https://github.com/JordanOsterberg/JScoreboards) with [scoreboard-library](https://github.com/MegavexNetwork/scoreboard-library), which utilises TextComponents instead of Strings. This should be tested for unexpected behaviours.