### PR TITLE
OinkScoreboard Integration

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/PluginMessageReceiver.java
+++ b/src/main/java/me/makkuusen/timing/system/PluginMessageReceiver.java
@@ -1,5 +1,7 @@
 package me.makkuusen.timing.system;
 
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteStreams;
 import me.makkuusen.timing.system.boatutils.BoatUtilsManager;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
@@ -10,6 +12,17 @@ public class PluginMessageReceiver implements PluginMessageListener {
     public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
         if (channel.equalsIgnoreCase("openboatutils:settings")){
             BoatUtilsManager.pluginMessageListener(channel, player, message);
+            return;
+        }
+
+        if(channel.equalsIgnoreCase("oinkscoreboard:settings")) {
+            ByteArrayDataInput in = ByteStreams.newDataInput(message);
+            short packetID = in.readByte();
+            if (packetID == 0) {
+                TPlayer tPlayer = Database.getPlayer(player.getUniqueId());
+                tPlayer.setOinkScoreboardRows(in.readByte());
+                System.out.println(player.getName() + " " + tPlayer.getOinkScoreboardRows());
+            }
             return;
         }
 

--- a/src/main/java/me/makkuusen/timing/system/TPlayer.java
+++ b/src/main/java/me/makkuusen/timing/system/TPlayer.java
@@ -19,6 +19,7 @@ import net.megavex.scoreboardlibrary.api.sidebar.Sidebar;
 import org.bukkit.Material;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Range;
 
 import java.awt.*;
 import java.util.List;
@@ -45,6 +46,7 @@ public class TPlayer implements Comparable<TPlayer> {
     private Track.TrackType trackType;
     private Integer page;
     private Integer boatUtilsVersion = null;
+    private Integer oinkScoreboardRows = null;
 
 
     public TPlayer(TimingSystem plugin, DbRow data) {
@@ -249,6 +251,18 @@ public class TPlayer implements Comparable<TPlayer> {
 
     public void setBoatUtilsVersion(Integer boatUtilsVersion) {
         this.boatUtilsVersion = boatUtilsVersion;
+    }
+
+    public void setOinkScoreboardRows(@Range(from = 0, to = 125) int rows) {
+        oinkScoreboardRows = rows;
+    }
+
+    public int getOinkScoreboardRows() {
+        return oinkScoreboardRows;
+    }
+
+    public boolean hasOinkScoreboard() {
+        return oinkScoreboardRows != null;
     }
 
     public boolean isSound() {

--- a/src/main/java/me/makkuusen/timing/system/TimingSystem.java
+++ b/src/main/java/me/makkuusen/timing/system/TimingSystem.java
@@ -88,8 +88,10 @@ public class TimingSystem extends JavaPlugin {
         pm.registerEvents(new GUIListener(), plugin);
         pm.registerEvents(new TSListener(), plugin);
         pm.registerEvents(new TimeTrialListener(), plugin);
-        Bukkit.getMessenger().registerIncomingPluginChannel(plugin, "openboatutils:settings", new PluginMessageReceiver());
+        PluginMessageReceiver receiver = new PluginMessageReceiver();
+        Bukkit.getMessenger().registerIncomingPluginChannel(plugin, "openboatutils:settings", receiver);
         Bukkit.getMessenger().registerOutgoingPluginChannel(plugin, "openboatutils:settings");
+        Bukkit.getMessenger().registerIncomingPluginChannel(plugin, "oinkscoreboard:settings", receiver);
 
         GuiCommon.init();
 

--- a/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/DriverScoreboard.java
@@ -83,7 +83,7 @@ public class DriverScoreboard {
     public List<Component> normalScoreboard() {
         List<Component> lines = new ArrayList<>();
         int count = 0;
-        int last = TimingSystem.configuration.getScoreboardMaxRows();
+        int last = Math.min(TimingSystem.configuration.getScoreboardMaxRows(), (tPlayer.hasOinkScoreboard() ? tPlayer.getOinkScoreboardRows() : 15));
         for (Driver driver : heat.getLivePositions()) {
             count++;
             if (count > last) {

--- a/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
+++ b/src/main/java/me/makkuusen/timing/system/heat/SpectatorScoreboard.java
@@ -58,7 +58,7 @@ public class SpectatorScoreboard {
     public List<Component> normalScoreboard(TPlayer tPlayer) {
         List<Component> lines = new ArrayList<>();
         int count = 0;
-        int last = TimingSystem.configuration.getScoreboardMaxRows();
+        int last = Math.min(TimingSystem.configuration.getScoreboardMaxRows(), (tPlayer.hasOinkScoreboard() ? tPlayer.getOinkScoreboardRows() : 15));
         Driver prevDriver = null;
         boolean compareToFirst = true;
         for (Driver driver : heat.getLivePositions()) {


### PR DESCRIPTION
This allows OinkScoreboard to send the amount of rows the player wants. The scoreboard will then display that amount of rows, capped by the server limit specified in the config. If they don't have the mod, the amount of rows sent is the lowest value between the config amount and 15.