### PR TITLE
Adds permission for /track info <track> <player>

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
@@ -233,7 +233,7 @@ public class CommandTrack extends BaseCommand {
     public static void onInfo(CommandSender commandSender, Track track, @Optional String name) {
 
         TPlayer tPlayer;
-        if (name != null && commandSender.hasPermission("track.admin")) {
+        if (name != null && commandSender.hasPermission("track.operator")) {
             tPlayer = Database.getPlayer(name);
             if (tPlayer == null) {
                 Text.send(commandSender, Error.PLAYER_NOT_FOUND);

--- a/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
+++ b/src/main/java/me/makkuusen/timing/system/commands/CommandTrack.java
@@ -233,7 +233,7 @@ public class CommandTrack extends BaseCommand {
     public static void onInfo(CommandSender commandSender, Track track, @Optional String name) {
 
         TPlayer tPlayer;
-        if (name != null && commandSender.isOp()) {
+        if (name != null && commandSender.hasPermission("track.admin")) {
             tPlayer = Database.getPlayer(name);
             if (tPlayer == null) {
                 Text.send(commandSender, Error.PLAYER_NOT_FOUND);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,6 +41,9 @@ permissions:
    track.admin:
       description: Player can admin tracks
       default: op
+   track.operator:
+      description: Player can access operator only track information.
+      default: op
    event.admin:
       description: Player can admin events
       default: op


### PR DESCRIPTION
Previously, this command was operator only.
Now this command can be used by players with the `track.operator` permission.

Would close Makkuusen/TimingSystem#269