### PR TITLE
openboatutils slime slipperiness fix

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/boatutils/BoatUtilsMode.java
+++ b/src/main/java/me/makkuusen/timing/system/boatutils/BoatUtilsMode.java
@@ -2,14 +2,22 @@ package me.makkuusen.timing.system.boatutils;
 
 public enum BoatUtilsMode {
     VANILLA(-1, 0),
-    RALLY(0, 0),
-    RALLY_BLUE(1, 0),
-    BA_NOFD(2, 0),
-    PARKOUR(3, 0),
-    BA_BLUE_NOFD(4,2),
-    PARKOUR_BLUE(5, 4),
-    BA(6, 4),
-    BA_BLUE(7, 4);
+    BROKEN_SLIME_RALLY(0, 0),
+    BROKEN_SLIME_RALLY_BLUE(1, 0),
+    BROKEN_SLIME_BA_NOFD(2, 0),
+    BROKEN_SLIME_PARKOUR(3, 0),
+    BROKEN_SLIME_BA_BLUE_NOFD(4,2),
+    BROKEN_SLIME_PARKOUR_BLUE(5, 4),
+    BROKEN_SLIME_BA(6, 4),
+    BROKEN_SLIME_BA_BLUE(7, 4),
+    RALLY(8, 5),
+    RALLY_BLUE(9, 5),
+    BA_NOFD(10, 5),
+    PARKOUR(11, 5),
+    BA_BLUE_NOFD(12, 5),
+    PARKOUR_BLUE(13, 5),
+    BA(14, 5),
+    BA_BLUE(15, 5);
 
     private final short id;
     private final short version;


### PR DESCRIPTION
due to an unfortunate typo, old versions of openboatutils (<0.3.1 or version id 5) gave slime blocks default slipperiness instead of 0.8, making tracks like Terra2 impossible. 
this is now fixed, however for compatibility with current tracks the "broken slime" needed to be kept, so all existing modes are now renamed with `BROKEN_SLIME_` at the start and replicate the behavior of the bug that gave slime blocks default slipperiness. 
there are new modes which do not have broken slime and should be the default going forward.

i am unfamiliar with TimingSystem's codebase and don't have a testing environment for it so i'm not sure if more needs to be done other than renaming and adding modes to the enum. 