### PR TITLE
Convert BoatUtilsMode to id instead of text field in TrackExchange

### DIFF
--- a/src/main/java/me/makkuusen/timing/system/track/TrackDatabase.java
+++ b/src/main/java/me/makkuusen/timing/system/track/TrackDatabase.java
@@ -248,11 +248,14 @@ public class TrackDatabase {
         }
     }
 
-    public static Track trackNewFromTrackExchange(TrackExchangeTrack trackExchangeTrack, Location newSpawnLocation, Vector offset) {
+    public static Track trackNewFromTrackExchange(TrackExchangeTrack trackExchangeTrack, Location newSpawnLocation, Vector offset, Player player) {
         try {
             World world = newSpawnLocation.getWorld();
             String name = trackExchangeTrack.getName();
             UUID uuid = trackExchangeTrack.getOwnerUUID();
+            if (Database.getPlayer(uuid) == null) {
+                uuid = player.getUniqueId();
+            }
             long dateCreated = trackExchangeTrack.getDateCreated();
             Track.TrackType trackType = trackExchangeTrack.getTrackType();
             Track.TrackMode trackMode = trackExchangeTrack.getTrackMode();
@@ -261,7 +264,7 @@ public class TrackDatabase {
             BoatUtilsMode boatUtilsMode = trackExchangeTrack.getBoatUtilsMode();
 
             // Create track
-            var trackId = DB.executeInsert("INSERT INTO `ts_tracks` (`uuid`, `name`, `dateCreated`, `weight`, `guiItem`, `spawn`, `leaderboard`, `type`, `mode`, `toggleOpen`, `options`, `boatUtilsMode`, `isRemoved`) " + "VALUES('" + uuid + "', " + Database.sqlString(name) + ", " + dateCreated + ", " + weight + ", " + Database.sqlString(ApiUtilities.itemToString(gui)) + ", '" + ApiUtilities.locationToString(newSpawnLocation) + "', '" + ApiUtilities.locationToString(newSpawnLocation) + "', " + Database.sqlString(trackType.toString()) + "," + Database.sqlString(trackMode.toString()) + ", 0, NULL, " + Database.sqlString(boatUtilsMode.toString()) + " , 0);");
+            var trackId = DB.executeInsert("INSERT INTO `ts_tracks` (`uuid`, `name`, `dateCreated`, `weight`, `guiItem`, `spawn`, `leaderboard`, `type`, `mode`, `toggleOpen`, `options`, `boatUtilsMode`, `isRemoved`) " + "VALUES('" + uuid + "', " + Database.sqlString(name) + ", " + dateCreated + ", " + weight + ", " + Database.sqlString(ApiUtilities.itemToString(gui)) + ", '" + ApiUtilities.locationToString(newSpawnLocation) + "', '" + ApiUtilities.locationToString(newSpawnLocation) + "', " + Database.sqlString(trackType.toString()) + "," + Database.sqlString(trackMode.toString()) + ", 0, NULL, " + boatUtilsMode.getId() + " , 0);");
             var dbRow = DB.getFirstRow("SELECT * FROM `ts_tracks` WHERE `id` = " + trackId + ";");
 
             Track rTrack = new Track(dbRow);

--- a/src/main/java/me/makkuusen/timing/system/track/TrackExchangeTrack.java
+++ b/src/main/java/me/makkuusen/timing/system/track/TrackExchangeTrack.java
@@ -52,7 +52,7 @@ public class TrackExchangeTrack implements Serializable {
     private String spawnLocation;
     private String trackType;
     private String trackMode;
-    private String boatUtilsMode;
+    private Integer boatUtilsMode;
     private Integer weight;
     private String options;
     private Long totalTimeSpent;
@@ -75,7 +75,7 @@ public class TrackExchangeTrack implements Serializable {
         spawnLocation = ApiUtilities.locationToString(track.getSpawnLocation());
         trackType = track.getType().toString();
         trackMode = track.getMode().toString();
-        boatUtilsMode = track.getBoatUtilsMode().toString();
+        boatUtilsMode = (int) track.getBoatUtilsMode().getId();
         weight = track.getWeight();
         options = Arrays.toString(track.getOptions());
         totalTimeSpent = track.getTotalTimeSpent();
@@ -195,7 +195,7 @@ public class TrackExchangeTrack implements Serializable {
         Vector offset = getOffset(ApiUtilities.stringToLocation(trackExchangeTrack.origin).toBlockLocation(), player.getLocation().toBlockLocation());
         Location newSpawnLocation = getNewLocation(player.getWorld(), ApiUtilities.stringToLocation(trackExchangeTrack.spawnLocation), offset);
 
-        trackExchangeTrack.track = TrackDatabase.trackNewFromTrackExchange(trackExchangeTrack, newSpawnLocation, offset);
+        trackExchangeTrack.track = TrackDatabase.trackNewFromTrackExchange(trackExchangeTrack, newSpawnLocation, offset, player);
 
         try(ClipboardReader clipboardReader = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getReader(new FileInputStream(trackSchematicFile))) {
             trackExchangeTrack.clipboard = clipboardReader.read();
@@ -231,7 +231,7 @@ public class TrackExchangeTrack implements Serializable {
     }
 
     public BoatUtilsMode getBoatUtilsMode() {
-        return BoatUtilsMode.valueOf(boatUtilsMode);
+        return BoatUtilsMode.getMode(boatUtilsMode);
     }
 
     public Vector getClipboardOffset() {


### PR DESCRIPTION
I also made sure that when importing a track with a creator of someone that doesn't exist in the database. It changes the owner to yourself to avoid crashing TimingSystem.